### PR TITLE
[Fix]: update game link

### DIFF
--- a/dtbot.js
+++ b/dtbot.js
@@ -132,8 +132,8 @@ async function inititalInfo() {
             // console.log(cookie)
             cookieTime = moment()
 
-            // console.log(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=3&hall=1`)
-            await axios.get(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=3&hall=1`,
+            // console.log(`https://bpweb.zeusmex555.com/player/singleDraTable.jsp?dm=1&t=${tableId}&title=1&sgt=3&hall=1`)
+            await axios.get(`https://bpweb.zeusmex555.com/player/singleDraTable.jsp?dm=1&t=${tableId}&title=1&sgt=3&hall=1`,
                 {
                     headers: {
                         Cookie: cookie
@@ -211,7 +211,7 @@ async function predictPlay() {
                 // cookie = await utils.reCookie(username, password, 4)
                 cookie = await reCookie(username, password)
                 cookieTime = moment()
-                await axios.get(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
+                await axios.get(`https://bpweb.zeusmex555.com/player/singleDraTable.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
                     {
                         headers: {
                             Cookie: cookie
@@ -267,7 +267,7 @@ async function predictPlay() {
                 // cookie = await utils.reCookie(username, password, 4)
                 cookie = await reCookie(username, password)
                 cookieTime = moment()
-                await axios.get(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
+                await axios.get(`https://bpweb.zeusmex555.com/player/singleDraTable.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
                     {
                         headers: {
                             Cookie: cookie

--- a/utilities/index.js
+++ b/utilities/index.js
@@ -1,9 +1,11 @@
 const cookie = require('./cookie');
 const credit = require('./credit');
 const login = require('./login');
+const sleep = require('./sleep');
 
 module.exports = {
   ...cookie,
   ...credit,
   ...login,
+  ...sleep,
 };

--- a/utilities/sleep.js
+++ b/utilities/sleep.js
@@ -1,0 +1,7 @@
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+module.exports = {
+  sleep,
+};

--- a/workerCode.js
+++ b/workerCode.js
@@ -131,8 +131,8 @@ async function inititalInfo() {
             // console.log(cookie)
             cookieTime = moment()
 
-            // console.log(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`)
-            await axios.get(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
+            // console.log(`https://bpweb.zeusmex555.com/player/singleBacTable.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`)
+            await axios.get(`https://bpweb.zeusmex555.com/player/singleBacTable.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
                 {
                     headers: {
                         Cookie: cookie
@@ -211,7 +211,7 @@ async function predictPlay() {
                 // cookie = await utils.reCookie(username, password, 4)
                 cookie = await reCookie(username, password)
                 cookieTime = moment()
-                await axios.get(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
+                await axios.get(`https://bpweb.zeusmex555.com/player/singleBacTable.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
                     {
                         headers: {
                             Cookie: cookie
@@ -266,7 +266,7 @@ async function predictPlay() {
                 // cookie = await utils.reCookie(username, password, 4)
                 cookie = await reCookie(username, password)
                 cookieTime = moment()
-                await axios.get(`https://bpweb.zeusmex555.com/player/singleTable4.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
+                await axios.get(`https://bpweb.zeusmex555.com/player/singleBacTable.jsp?dm=1&t=${tableId}&title=1&sgt=0&hall=1`,
                     {
                         headers: {
                             Cookie: cookie


### PR DESCRIPTION
## Problem

Bot call to `deprecated` URL to initial connection to game table and it response `404`. And that cause 2 problems.
1. Bot try to `reCookie` and that make `429` too many requests
2. Bot cannot get game data in endpoint `queryDealerEventV2`

## Solutions

Update link to initial connection to `bac...` and `dra...`. And improve logic in `reCookie` to waiting another connection.